### PR TITLE
Oda 340

### DIFF
--- a/oda-operations/update/src/main/java/es/amplia/oda/operation/update/DownloadManager.java
+++ b/oda-operations/update/src/main/java/es/amplia/oda/operation/update/DownloadManager.java
@@ -17,5 +17,5 @@ public interface DownloadManager {
 
     void deleteDownloadedFiles();
 
-    void loadConfig(String rulesPath, String deployPath, String configutationPath, String downloadsPath);
+    void loadConfig(String rulesPath, String rulesUtilsPath, String deployPath, String configutationPath, String downloadsPath);
 }

--- a/oda-operations/update/src/main/java/es/amplia/oda/operation/update/InstallManager.java
+++ b/oda-operations/update/src/main/java/es/amplia/oda/operation/update/InstallManager.java
@@ -19,5 +19,5 @@ public interface InstallManager {
 
     void clearInstalledDeploymentElements();
 
-    void loadConfig(String rulesPath, String deployPath, String configurationPath);
+    void loadConfig(String rulesPath, String rulesUtilsPath, String deployPath, String configurationPath);
 }

--- a/oda-operations/update/src/main/java/es/amplia/oda/operation/update/OperationUpdateImpl.java
+++ b/oda-operations/update/src/main/java/es/amplia/oda/operation/update/OperationUpdateImpl.java
@@ -180,8 +180,10 @@ public class OperationUpdateImpl implements OperationUpdate {
 
     public void loadConfiguration(UpdateConfiguration config) {
         rulesPath = config.getRulesPath();
-        installManager.loadConfig(rulesPath, config.getDeployPath(), config.getConfigurationPath());
-        downloadManager.loadConfig(rulesPath, config.getDeployPath(), config.getConfigurationPath(), config.getDownloadsPath());
+        installManager.loadConfig(rulesPath, config.getRulesUtilsPath(), config.getDeployPath(),
+                config.getConfigurationPath());
+        downloadManager.loadConfig(rulesPath, config.getRulesUtilsPath(), config.getDeployPath(),
+                config.getConfigurationPath(), config.getDownloadsPath());
         backupManager.loadConfig(config.getBackupPath());
     }
 }

--- a/oda-operations/update/src/main/java/es/amplia/oda/operation/update/configuration/UpdateConfiguration.java
+++ b/oda-operations/update/src/main/java/es/amplia/oda/operation/update/configuration/UpdateConfiguration.java
@@ -7,6 +7,7 @@ import lombok.Value;
 @Builder
 public class UpdateConfiguration {
 	String rulesPath;
+	String rulesUtilsPath;
 	String backupPath;
 	String deployPath;
 	String downloadsPath;

--- a/oda-operations/update/src/main/java/es/amplia/oda/operation/update/configuration/UpdateConfigurationHandler.java
+++ b/oda-operations/update/src/main/java/es/amplia/oda/operation/update/configuration/UpdateConfigurationHandler.java
@@ -15,6 +15,7 @@ public class UpdateConfigurationHandler implements ConfigurationUpdateHandler {
 	private static final Logger LOGGER = LoggerFactory.getLogger(UpdateConfigurationHandler.class);
 
 	static final String RULES_PATH_PROPERTY_NAME = "rulesPath";
+	static final String RULES_UTILS_PATH_PROPERTY_NAME = "rulesUtilsPath";
 	static final String BACKUP_PATH_PROPERTY_NAME = "backupPath";
 	static final String DEPLOY_PATH_PROPERTY_NAME = "deployPath";
 	static final String DOWNLOADS_PATH_PROPERTY_NAME = "downloadsPath";
@@ -34,6 +35,8 @@ public class UpdateConfigurationHandler implements ConfigurationUpdateHandler {
 		UpdateConfiguration.UpdateConfigurationBuilder builder = UpdateConfiguration.builder();
 
 		builder.rulesPath(Optional.ofNullable((String) props.get(RULES_PATH_PROPERTY_NAME))
+				.orElseThrow(() ->  missingPathExceptionSupplier().get()));
+		builder.rulesUtilsPath(Optional.ofNullable((String) props.get(RULES_UTILS_PATH_PROPERTY_NAME))
 				.orElseThrow(() ->  missingPathExceptionSupplier().get()));
 		builder.backupPath(Optional.ofNullable((String) props.get(BACKUP_PATH_PROPERTY_NAME))
 				.orElseThrow(() ->  missingPathExceptionSupplier().get()));

--- a/oda-operations/update/src/main/java/es/amplia/oda/operation/update/internal/DownloadManagerImpl.java
+++ b/oda-operations/update/src/main/java/es/amplia/oda/operation/update/internal/DownloadManagerImpl.java
@@ -33,6 +33,7 @@ public class DownloadManagerImpl implements DownloadManager {
     private final Map<DeploymentElement, String> downloadedFiles = new HashMap<>();
 
     private String rulesPath;
+    private String rulesUtilsPath;
     private String deployPath= "deploy/";
     private String configurationPath= "configuration/";
     private String downloadsPath= "downloads/";
@@ -87,12 +88,13 @@ public class DownloadManagerImpl implements DownloadManager {
     }
 
     private String getDeploymentElementLocalFilePath(DeploymentElement deploymentElement) {
-        if(deploymentElement.getPath().equals(deployPath)) {
+        if (deploymentElement.getPath().equals(deployPath)) {
             return downloadsPath + deploymentElement.getName() + "-" + deploymentElement.getVersion() + ".jar";
-        } else if(deploymentElement.getPath().equals(configurationPath)) {
+        } else if (deploymentElement.getPath().equals(configurationPath)) {
             return downloadsPath + deploymentElement.getName() + ".cfg";
         } else {
-            if (deploymentElement.getPath().startsWith(rulesPath)) {
+            if (deploymentElement.getPath().startsWith(rulesPath)
+                    || deploymentElement.getPath().startsWith(rulesUtilsPath)) {
                 return downloadsPath + deploymentElement.getName() + ".js";
             }
             return downloadsPath + deploymentElement.getName();
@@ -122,8 +124,10 @@ public class DownloadManagerImpl implements DownloadManager {
     }
 
     @Override
-    public void loadConfig(String rulesPath, String deployPath, String configurationPath, String downloadsPath) {
+    public void loadConfig(String rulesPath, String rulesUtilsPath, String deployPath, String configurationPath,
+                           String downloadsPath) {
         this.rulesPath = rulesPath;
+        this.rulesUtilsPath = rulesUtilsPath;
         this.deployPath = deployPath;
         this.configurationPath = configurationPath;
         this.downloadsPath = downloadsPath;

--- a/oda-operations/update/src/main/java/es/amplia/oda/operation/update/internal/InstallManagerImpl.java
+++ b/oda-operations/update/src/main/java/es/amplia/oda/operation/update/internal/InstallManagerImpl.java
@@ -23,6 +23,7 @@ public class InstallManagerImpl implements InstallManager {
     private final Map<DeploymentElement, DeploymentElementOperation> installedDeploymentElements = new HashMap<>();
 
     private String rulesPath;
+    private String rulesUtilsPath;
     private String deployPath= "deploy/";
     private String configurationPath= "configuration/";
 
@@ -31,14 +32,15 @@ public class InstallManagerImpl implements InstallManager {
     }
 
     public DeploymentElement assignDeployElementType(DeploymentElement deploymentElement) {
-        if(deploymentElement.getPath().equals(deployPath)) {
+        if (deploymentElement.getPath().equals(deployPath)) {
             deploymentElement.setType(OperationUpdate.DeploymentElementType.SOFTWARE);
             return deploymentElement;
         } else if (deploymentElement.getPath().equals(configurationPath)) {
             deploymentElement.setType(OperationUpdate.DeploymentElementType.CONFIGURATION);
             return deploymentElement;
         } else {
-            if (deploymentElement.getPath().startsWith(rulesPath)) {
+            if (deploymentElement.getPath().startsWith(rulesPath)
+                    || deploymentElement.getPath().startsWith(rulesUtilsPath)) {
                 deploymentElement.setType(OperationUpdate.DeploymentElementType.RULE);
             } else {
                 deploymentElement.setType(OperationUpdate.DeploymentElementType.DEFAULT);
@@ -58,7 +60,7 @@ public class InstallManagerImpl implements InstallManager {
             deploymentElement = assignDeployElementType(deploymentElement);
             operation =
                     deploymentElementOperationFactory.createDeploymentElementOperation(deploymentElement, localFile,
-                            deploymentElement.getPath(), rulesPath);
+                            deploymentElement.getPath(), rulesPath, rulesUtilsPath);
             operation.execute();
         } catch (DeploymentElementOperationException exception) {
             throw new InstallException(exception.getMessage());
@@ -95,8 +97,9 @@ public class InstallManagerImpl implements InstallManager {
     }
 
     @Override
-    public void loadConfig(String rulesPath, String deployPath, String configurationPath) {
+    public void loadConfig(String rulesPath, String rulesUtilsPath, String deployPath, String configurationPath) {
         this.rulesPath = rulesPath;
+        this.rulesUtilsPath = rulesUtilsPath;
         this.deployPath = deployPath;
         this.configurationPath = configurationPath;
     }

--- a/oda-operations/update/src/main/java/es/amplia/oda/operation/update/operations/DeploymentElementOperationFactory.java
+++ b/oda-operations/update/src/main/java/es/amplia/oda/operation/update/operations/DeploymentElementOperationFactory.java
@@ -21,20 +21,22 @@ public class DeploymentElementOperationFactory {
 
     public DeploymentElementOperation createDeploymentElementOperation (DeploymentElement deploymentElement,
                                                                         String localFile, String installFolder,
-                                                                        String rulesPath) {
+                                                                        String rulesPath, String rulesUtilsPath) {
         OperationUpdate.DeploymentElementOperationType operation = deploymentElement.getOperation();
         switch (operation) {
             case INSTALL:
-                if (deploymentElement.getPath().startsWith(rulesPath)) {
-                    return new InstallRuleDeploymentElementOperation(deploymentElement, localFile , installFolder, fileManager,
-                            operationConfirmationProcessor, rulesPath);
+                if (deploymentElement.getPath().startsWith(rulesPath)
+                        || deploymentElement.getPath().startsWith(rulesUtilsPath)) {
+                    return new InstallRuleDeploymentElementOperation(deploymentElement, localFile, installFolder, fileManager,
+                            operationConfirmationProcessor);
                 }
                 return new InstallDeploymentElementOperation(deploymentElement, localFile, installFolder, fileManager,
                         operationConfirmationProcessor);
             case UPGRADE:
-                if (deploymentElement.getPath().startsWith(rulesPath)) {
+                if (deploymentElement.getPath().startsWith(rulesPath)
+                        || deploymentElement.getPath().startsWith(rulesUtilsPath)) {
                     return new UpgradeRuleDeploymentElementOperation(deploymentElement, localFile, installFolder, fileManager,
-                            operationConfirmationProcessor, rulesPath);
+                            operationConfirmationProcessor);
                 }
                 return new UpgradeDeploymentElementOperation(deploymentElement, localFile, installFolder, fileManager,
                         operationConfirmationProcessor);

--- a/oda-operations/update/src/main/java/es/amplia/oda/operation/update/operations/InstallRuleDeploymentElementOperation.java
+++ b/oda-operations/update/src/main/java/es/amplia/oda/operation/update/operations/InstallRuleDeploymentElementOperation.java
@@ -11,22 +11,18 @@ import static es.amplia.oda.operation.update.FileManager.FileException;
 
 public class InstallRuleDeploymentElementOperation extends DeploymentElementOperationBase {
 
-    private static final String LIB_FILE = "utils.js";
 
     private final String localFile;
     private final String installFolder;
-    private final String toInsert;
 
     private String installedFile;
 
     InstallRuleDeploymentElementOperation(DeploymentElement deploymentElement, String localFile, String installFolder,
 										  FileManager fileManager,
-										  OperationConfirmationProcessor operationConfirmationProcessor,
-                                          String rulesPath) {
+										  OperationConfirmationProcessor operationConfirmationProcessor) {
         super(deploymentElement, fileManager, operationConfirmationProcessor);
         this.localFile = localFile;
         this.installFolder = installFolder;
-        this.toInsert = "load(\"" + System.getProperty("user.dir") + "/" + rulesPath + LIB_FILE + "\");\n\n";
     }
 
     @Override
@@ -37,7 +33,6 @@ public class InstallRuleDeploymentElementOperation extends DeploymentElementOper
                 throw new IOException("Impossible create new directory of rule's datastream");
             }
             installedFile = fileManager.copy(localFile, installFolder);
-            fileManager.insertInFile(toInsert, 0, installedFile);
         } catch (IOException e) {
             throw new FileException(e.getMessage());
         }

--- a/oda-operations/update/src/main/java/es/amplia/oda/operation/update/operations/UpgradeRuleDeploymentElementOperation.java
+++ b/oda-operations/update/src/main/java/es/amplia/oda/operation/update/operations/UpgradeRuleDeploymentElementOperation.java
@@ -3,45 +3,34 @@ package es.amplia.oda.operation.update.operations;
 import es.amplia.oda.operation.update.FileManager;
 import es.amplia.oda.operation.update.OperationConfirmationProcessor;
 
-import java.io.IOException;
 
 import static es.amplia.oda.operation.api.OperationUpdate.DeploymentElement;
 import static es.amplia.oda.operation.update.FileManager.FileException;
 
 public class UpgradeRuleDeploymentElementOperation extends DeploymentElementOperationBase {
 
-    private static final String LIB_FILE = "utils.js";
-
     private final String localFile;
     private final String installFolder;
-    private final String toInsert;
 
     private String upgradedFile;
 
     UpgradeRuleDeploymentElementOperation(DeploymentElement deploymentElement, String localFile, String installFolder,
 										  FileManager fileManager,
-										  OperationConfirmationProcessor operationConfirmationProcessor,
-                                          String rulesPath) {
+										  OperationConfirmationProcessor operationConfirmationProcessor) {
         super(deploymentElement, fileManager, operationConfirmationProcessor);
         this.localFile = localFile;
         this.installFolder = installFolder;
-        this.toInsert = "load(\"" + System.getProperty("user.dir") + "/" + rulesPath + LIB_FILE + "\");\n\n";
     }
 
     @Override
     protected void executeSpecificOperation(FileManager fileManager)
             throws FileException, DeploymentElementOperationException {
-        try {
-            String installedFile = fileManager.find(installFolder, getName());
-            if (installedFile == null) {
-                throw new DeploymentElementOperationException("Deployment element file to upgrade is not found");
-            }
-            fileManager.delete(installedFile);
-            upgradedFile = fileManager.copy(localFile, installFolder);
-            fileManager.insertInFile(toInsert, 0, upgradedFile);
-        } catch (IOException e) {
-            throw new FileException(e.getMessage());
+        String installedFile = fileManager.find(installFolder, getName());
+        if (installedFile == null) {
+            throw new DeploymentElementOperationException("Deployment element file to upgrade is not found");
         }
+        fileManager.delete(installedFile);
+        upgradedFile = fileManager.copy(localFile, installFolder);
     }
 
     @Override

--- a/oda-operations/update/src/test/java/es/amplia/oda/operation/update/internal/DownloadManagerImplTest.java
+++ b/oda-operations/update/src/test/java/es/amplia/oda/operation/update/internal/DownloadManagerImplTest.java
@@ -78,7 +78,8 @@ public class DownloadManagerImplTest {
         downloadedFiles.put(deploymentElement3, DOWNLOADED_FILE_3);
         spiedDownloadedFiles = spy(downloadedFiles);
 
-        testDownloadManager.loadConfig("rules/", "deploy/", "configuration/", "downloads/");
+        testDownloadManager.loadConfig("rules/", "jslib/", "deploy/",
+                "configuration/", "downloads/");
     }
 
     @Test

--- a/oda-operations/update/src/test/java/es/amplia/oda/operation/update/internal/InstallManagerImplTest.java
+++ b/oda-operations/update/src/test/java/es/amplia/oda/operation/update/internal/InstallManagerImplTest.java
@@ -30,6 +30,7 @@ public class InstallManagerImplTest {
     private static final String LOCAL_FILE = "path/to/element/to/install.jar";
     private static final String PATH_TO_BACKUP_JAR = "path/to/backup.jar";
     private static final String PATH_TO_RULES = "rules/";
+    private static final String PATH_TO_RULES_UTILS = "jslib/";
     private static final String PATH_TO_SOFTWARE = "deploy/";
     private static final String PATH_TO_CONFIGURATION = "configuration/";
     private static final String INSTALLED_DEPLOYMENT_ELEMENTS_FIELD_NAME = "installedDeploymentElements";
@@ -85,7 +86,7 @@ public class InstallManagerImplTest {
         installedOperations.put(uninstallSoftwareElement, uninstallSoftwareOperation);
         spiedInstalledElements = spy(installedOperations);
 
-        testInstallManager.loadConfig(PATH_TO_RULES, PATH_TO_SOFTWARE, PATH_TO_CONFIGURATION);
+        testInstallManager.loadConfig(PATH_TO_RULES, PATH_TO_RULES_UTILS, PATH_TO_SOFTWARE, PATH_TO_CONFIGURATION);
     }
 
     @Test
@@ -115,15 +116,17 @@ public class InstallManagerImplTest {
     public void testInstallInstallSoftware() throws InstallException, DeploymentElementOperationException {
         Whitebox.setInternalState(testInstallManager, INSTALLED_DEPLOYMENT_ELEMENTS_FIELD_NAME, spiedEmptyInstalledElements);
 
-        when(mockedFactory.createDeploymentElementOperation(any(DeploymentElement.class), anyString(), anyString(), anyString()))
+        when(mockedFactory.createDeploymentElementOperation(any(DeploymentElement.class), anyString(), anyString(),
+                anyString(), anyString()))
                 .thenReturn(installSoftwareOperation);
 
         testInstallManager.install(installSoftwareElement, LOCAL_FILE);
 
-        verify(mockedFactory).createDeploymentElementOperation (eq(installSoftwareElement),
-                                                                eq(LOCAL_FILE),
-                                                                eq(PATH_TO_SOFTWARE),
-                                                                eq(PATH_TO_RULES));
+        verify(mockedFactory).createDeploymentElementOperation(eq(installSoftwareElement),
+                eq(LOCAL_FILE),
+                eq(PATH_TO_SOFTWARE),
+                eq(PATH_TO_RULES),
+                eq(PATH_TO_RULES_UTILS));
         verify(installSoftwareOperation).execute();
         verify(spiedEmptyInstalledElements).put(eq(installSoftwareElement), eq(installSoftwareOperation));
     }
@@ -132,15 +135,16 @@ public class InstallManagerImplTest {
     public void testInstallUpgradeConfiguration() throws InstallException, DeploymentElementOperationException {
         Whitebox.setInternalState(testInstallManager, INSTALLED_DEPLOYMENT_ELEMENTS_FIELD_NAME, spiedEmptyInstalledElements);
 
-        when(mockedFactory.createDeploymentElementOperation(any(DeploymentElement.class), anyString(), anyString(), anyString()))
-                .thenReturn(upgradeConfigurationOperation);
+        when(mockedFactory.createDeploymentElementOperation(any(DeploymentElement.class), anyString(), anyString()
+                , anyString(), anyString())).thenReturn(upgradeConfigurationOperation);
 
         testInstallManager.install(upgradeConfigurationElement, LOCAL_FILE);
 
-        verify(mockedFactory).createDeploymentElementOperation (eq(upgradeConfigurationElement),
-                                                                eq(LOCAL_FILE),
-                                                                eq(PATH_TO_CONFIGURATION),
-                                                                eq(PATH_TO_RULES));
+        verify(mockedFactory).createDeploymentElementOperation(eq(upgradeConfigurationElement),
+                eq(LOCAL_FILE),
+                eq(PATH_TO_CONFIGURATION),
+                eq(PATH_TO_RULES),
+                eq(PATH_TO_RULES_UTILS));
         verify(upgradeConfigurationOperation).execute();
         verify(spiedEmptyInstalledElements).put(eq(upgradeConfigurationElement), eq(upgradeConfigurationOperation));
     }
@@ -149,15 +153,16 @@ public class InstallManagerImplTest {
     public void testInstallUninstallSoftware() throws InstallException, DeploymentElementOperationException {
         Whitebox.setInternalState(testInstallManager, INSTALLED_DEPLOYMENT_ELEMENTS_FIELD_NAME, spiedEmptyInstalledElements);
 
-        when(mockedFactory.createDeploymentElementOperation(any(DeploymentElement.class), anyString(), anyString(), anyString()))
-                .thenReturn(uninstallSoftwareOperation);
+        when(mockedFactory.createDeploymentElementOperation(any(DeploymentElement.class), anyString(), anyString(),
+                anyString(), anyString())).thenReturn(uninstallSoftwareOperation);
 
         testInstallManager.install(uninstallSoftwareElement, LOCAL_FILE);
 
         verify(mockedFactory).createDeploymentElementOperation(eq(uninstallSoftwareElement),
                 eq(LOCAL_FILE),
                 eq(PATH_TO_SOFTWARE),
-                eq(PATH_TO_RULES));
+                eq(PATH_TO_RULES),
+                eq(PATH_TO_RULES_UTILS));
         verify(uninstallSoftwareOperation).execute();
         verify(spiedEmptyInstalledElements).put(eq(uninstallSoftwareElement), eq(uninstallSoftwareOperation));
     }
@@ -166,8 +171,8 @@ public class InstallManagerImplTest {
     public void testInstallInstallSoftwareException() throws InstallException, DeploymentElementOperationException {
         Whitebox.setInternalState(testInstallManager, INSTALLED_DEPLOYMENT_ELEMENTS_FIELD_NAME, spiedInstalledElements);
 
-        when(mockedFactory.createDeploymentElementOperation(any(DeploymentElement.class), anyString(), anyString(), anyString()))
-                .thenReturn(installSoftwareOperation);
+        when(mockedFactory.createDeploymentElementOperation(any(DeploymentElement.class), anyString(), anyString(),
+                anyString(), anyString())).thenReturn(installSoftwareOperation);
         doThrow(new DeploymentElementOperationException("")).when(installSoftwareOperation).execute();
 
         try {

--- a/oda-operations/update/src/test/java/es/amplia/oda/operation/update/operations/DeploymentElementOperationFactoryTest.java
+++ b/oda-operations/update/src/test/java/es/amplia/oda/operation/update/operations/DeploymentElementOperationFactoryTest.java
@@ -27,6 +27,8 @@ public class DeploymentElementOperationFactoryTest {
     private static final String LOCAL_FILE_JAR = "path/to/local/file.jar";
     private static final String INSTALL_FOLDER = "path/to/install/folder";
     private static final String PATH_TO_RULES = "path/to/rules/files";
+    private static final String PATH_TO_RULES_UTILS = "path/to/jslib";
+
 
     @Mock
     private FileManager mockedFileManager;
@@ -64,7 +66,8 @@ public class DeploymentElementOperationFactoryTest {
 
         PowerMockito.whenNew(InstallDeploymentElementOperation.class).withAnyArguments().thenReturn(mockedInstallOp);
 
-        testFactory.createDeploymentElementOperation(installDeploymentElement, LOCAL_FILE_JAR, INSTALL_FOLDER, PATH_TO_RULES);
+        testFactory.createDeploymentElementOperation(installDeploymentElement, LOCAL_FILE_JAR, INSTALL_FOLDER,
+                PATH_TO_RULES, PATH_TO_RULES_UTILS);
 
         PowerMockito.verifyNew(InstallDeploymentElementOperation.class)
                 .withArguments(eq(installDeploymentElement), eq(LOCAL_FILE_JAR), eq(INSTALL_FOLDER), eq(mockedFileManager),
@@ -81,7 +84,8 @@ public class DeploymentElementOperationFactoryTest {
 
         PowerMockito.whenNew(UpgradeDeploymentElementOperation.class).withAnyArguments().thenReturn(mockedUpgradeOp);
 
-        testFactory.createDeploymentElementOperation(upgradeDeploymentElement, LOCAL_FILE_JAR, INSTALL_FOLDER, PATH_TO_RULES);
+        testFactory.createDeploymentElementOperation(upgradeDeploymentElement, LOCAL_FILE_JAR, INSTALL_FOLDER,
+                PATH_TO_RULES, PATH_TO_RULES_UTILS);
 
         PowerMockito.verifyNew(UpgradeDeploymentElementOperation.class)
                 .withArguments(eq(upgradeDeploymentElement), eq(LOCAL_FILE_JAR), eq(INSTALL_FOLDER), eq(mockedFileManager),
@@ -99,7 +103,8 @@ public class DeploymentElementOperationFactoryTest {
         PowerMockito.whenNew(UninstallDeploymentElementOperation.class).withAnyArguments()
                 .thenReturn(mockedUninstallOp);
 
-        testFactory.createDeploymentElementOperation(uninstallDeploymentElement, LOCAL_FILE_JAR, INSTALL_FOLDER, PATH_TO_RULES);
+        testFactory.createDeploymentElementOperation(uninstallDeploymentElement, LOCAL_FILE_JAR, INSTALL_FOLDER,
+                PATH_TO_RULES, PATH_TO_RULES_UTILS);
 
         PowerMockito.verifyNew(UninstallDeploymentElementOperation.class)
                 .withArguments(eq(uninstallDeploymentElement), eq(INSTALL_FOLDER), eq(mockedFileManager),

--- a/oda-operations/update/src/test/java/es/amplia/oda/operation/update/operations/InstallRuleDeploymentElementOperationTest.java
+++ b/oda-operations/update/src/test/java/es/amplia/oda/operation/update/operations/InstallRuleDeploymentElementOperationTest.java
@@ -42,8 +42,8 @@ public class InstallRuleDeploymentElementOperationTest {
 
     @Before
     public void setUp() {
-        testRulesInstallOperation = new InstallRuleDeploymentElementOperation(installDeploymentElement, LOCAL_FILE, PATH_TO_RULES_FILE,
-                mockedFileManager, mockedOperationConfirmationProcessor, PATH_TO_RULES);
+        testRulesInstallOperation = new InstallRuleDeploymentElementOperation(installDeploymentElement, LOCAL_FILE,
+                PATH_TO_RULES_FILE, mockedFileManager, mockedOperationConfirmationProcessor);
     }
 
     @AfterClass

--- a/oda-operations/update/src/test/java/es/amplia/oda/operation/update/operations/UpgradeRuleDeploymentElementOperationTest.java
+++ b/oda-operations/update/src/test/java/es/amplia/oda/operation/update/operations/UpgradeRuleDeploymentElementOperationTest.java
@@ -47,8 +47,8 @@ public class UpgradeRuleDeploymentElementOperationTest {
 
     @Before
     public void setUp() {
-        testUpgradeOperation = new UpgradeRuleDeploymentElementOperation(UPGRADE_DEPLOYMENT_ELEMENT, LOCAL_FILE, PATH_TO_RULES_FILE,
-                mockedFileManager, mockedOperationConfirmationProcessor, PATH_TO_RULES);
+        testUpgradeOperation = new UpgradeRuleDeploymentElementOperation(UPGRADE_DEPLOYMENT_ELEMENT,
+                LOCAL_FILE, PATH_TO_RULES_FILE, mockedFileManager, mockedOperationConfirmationProcessor);
     }
 
     @After

--- a/oda-ruleengine/api/src/main/java/es/amplia/oda/ruleengine/api/RuleEngine.java
+++ b/oda-ruleengine/api/src/main/java/es/amplia/oda/ruleengine/api/RuleEngine.java
@@ -4,10 +4,17 @@ import es.amplia.oda.core.commons.utils.State;
 import es.amplia.oda.core.commons.utils.DatastreamValue;
 
 public interface RuleEngine {
-	State engine(State state, DatastreamValue value) ;
+	State engine(State state, DatastreamValue value);
+
 	void createDatastreamDirectory(String nameRule);
+
 	void deleteDatastreamDirectory(String nameRule);
+
 	void createRule(String nameRule);
+
 	void deleteRule(String nameRule);
+
+	void reloadAllRules();
+
 	void stop();
 }

--- a/oda-ruleengine/api/src/main/java/es/amplia/oda/ruleengine/api/RuleEngineProxy.java
+++ b/oda-ruleengine/api/src/main/java/es/amplia/oda/ruleengine/api/RuleEngineProxy.java
@@ -39,6 +39,9 @@ public class RuleEngineProxy implements RuleEngine, AutoCloseable {
 	}
 
 	@Override
+	public void reloadAllRules() {proxy.consumeFirst(RuleEngine::reloadAllRules);}
+
+	@Override
 	public void stop() {
 		proxy.consumeFirst(RuleEngine::stop);
 	}

--- a/oda-ruleengine/api/src/main/java/es/amplia/oda/ruleengine/api/RulesUtilsDirectoryWatcher.java
+++ b/oda-ruleengine/api/src/main/java/es/amplia/oda/ruleengine/api/RulesUtilsDirectoryWatcher.java
@@ -1,0 +1,66 @@
+package es.amplia.oda.ruleengine.api;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+
+import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
+
+public class RulesUtilsDirectoryWatcher implements DirectoryWatcher {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(RulesUtilsDirectoryWatcher.class);
+
+	Path path;
+	RuleEngine engine;
+	WatchService creatingWatcher;
+
+	Thread creatingWatcherThread;
+
+
+	public RulesUtilsDirectoryWatcher(Path path, RuleEngine engine) {
+		this.path = path;
+		this.engine = engine;
+	}
+
+	@Override
+	public void start() {
+		try {
+			creatingWatcher = FileSystems.getDefault().newWatchService();
+			path.register(creatingWatcher, ENTRY_CREATE, ENTRY_DELETE);
+			creatingWatcherThread = new Thread(() -> {
+				try {
+					while (true) {
+						WatchKey key = creatingWatcher.take();
+						key.pollEvents().forEach(event -> {
+							// only check files ending with .js (javascript files)
+							// in linux, when a file is modified, a temporal file called goutputstream is created
+							// with this condition we avoid the watcher to detect this temporary file
+							if (event.context().toString().endsWith(".js")) {
+								// reload all rules
+								engine.reloadAllRules();
+							}
+						});
+						key.reset();
+					}
+				} catch (InterruptedException e) {
+					LOGGER.error("Something unexpected happened while watching the directory for changes. Watcher will be stopped", e);
+					Thread.currentThread().interrupt();
+				}
+			});
+			creatingWatcherThread.start();
+		} catch (IOException e) {
+			LOGGER.error("Error on Rules utils directory Watcher creation", e);
+		}
+	}
+
+	@Override
+	public void stop() {
+		creatingWatcherThread.interrupt();
+	}
+}

--- a/oda-ruleengine/api/src/test/java/es/amplia/oda/ruleengine/api/RuleEngineProxyTest.java
+++ b/oda-ruleengine/api/src/test/java/es/amplia/oda/ruleengine/api/RuleEngineProxyTest.java
@@ -26,7 +26,9 @@ import static org.mockito.Mockito.verify;
 public class RuleEngineProxyTest {
 
 	private static final String TEST_NAME_RULE = "nameRule";
-	private static final DatastreamValue TEST_DATASTREAM_VALUE = new DatastreamValue("testDevice", "testDatastream", System.currentTimeMillis(), true, DatastreamValue.Status.OK, "", false);
+	private static final DatastreamValue TEST_DATASTREAM_VALUE =
+			new DatastreamValue("testDevice", "testDatastream", System.currentTimeMillis(),
+					true, DatastreamValue.Status.OK, "", false);
 
 	@Mock
 	private BundleContext mockedContext;
@@ -110,6 +112,16 @@ public class RuleEngineProxyTest {
 				ruleEngineConsumerCaptor.getValue();
 		capturedFunction.accept(mockedRuleEngine);
 		verify(mockedRuleEngine).deleteRule(TEST_NAME_RULE);
+	}
+
+	@Test
+	public void testReloadAllRules() {
+		testProxy.reloadAllRules();
+
+		verify(mockedProxy).consumeFirst(ruleEngineConsumerCaptor.capture());
+		Consumer<RuleEngine> capturedFunction = ruleEngineConsumerCaptor.getValue();
+		capturedFunction.accept(mockedRuleEngine);
+		verify(mockedRuleEngine).reloadAllRules();
 	}
 
 	@Test

--- a/oda-ruleengine/api/src/test/java/es/amplia/oda/ruleengine/api/RulesUtilsDirectoryWatcherTest.java
+++ b/oda-ruleengine/api/src/test/java/es/amplia/oda/ruleengine/api/RulesUtilsDirectoryWatcherTest.java
@@ -1,0 +1,113 @@
+package es.amplia.oda.ruleengine.api;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchService;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(RulesUtilsDirectoryWatcher.class)
+public class RulesUtilsDirectoryWatcherTest {
+
+	@Mock
+	RuleEngine mockedEngine;
+	@Mock
+	Path mockedPath;
+
+	@InjectMocks
+	RulesUtilsDirectoryWatcher testDirectoryWatcher;
+
+	@Mock
+	Thread mockedThread;
+
+	@Test
+	public void testConstructor() {
+		String path = "this/is/a/path";
+
+		testDirectoryWatcher = new RulesUtilsDirectoryWatcher(Paths.get(path), mockedEngine);
+
+		assertEquals(Paths.get(path), Whitebox.getInternalState(testDirectoryWatcher, "path"));
+		assertEquals(mockedEngine, Whitebox.getInternalState(testDirectoryWatcher, "engine"));
+	}
+
+	@Test
+	public void testStart() throws Exception {
+		Whitebox.setInternalState(testDirectoryWatcher, "creatingWatcherThread", mockedThread);
+		whenNew(Thread.class).withAnyArguments().thenReturn(mockedThread);
+
+		testDirectoryWatcher.start();
+
+		verify(mockedPath).register(any(WatchService.class), eq(StandardWatchEventKinds.ENTRY_CREATE), eq(StandardWatchEventKinds.ENTRY_DELETE));
+		verify(mockedThread).start();
+	}
+
+	@Test
+	public void testThreadCreateEvent() throws InterruptedException, IOException {
+		String root = new File(".").getCanonicalPath();
+		String testRoute = root + "/src/test/java";
+		testDirectoryWatcher = new RulesUtilsDirectoryWatcher(Paths.get(testRoute), mockedEngine);
+
+		testDirectoryWatcher.start();
+
+		File fileToCreate = new File(testRoute + "/tempDir.js");
+		fileToCreate.createNewFile();
+
+		TimeUnit.MILLISECONDS.sleep(100);
+		verify(mockedEngine).reloadAllRules();
+	}
+
+	@Test
+	public void testThreadDeleteEvent() throws InterruptedException, IOException {
+		String root = new File(".").getCanonicalPath();
+		String testRoute = root + "/src/test/java";
+		testDirectoryWatcher = new RulesUtilsDirectoryWatcher(Paths.get(testRoute), mockedEngine);
+		File fileToCreate = new File(testRoute + "/tempDir.js");
+		fileToCreate.createNewFile();
+
+		testDirectoryWatcher.start();
+		fileToCreate.delete();
+
+		TimeUnit.MILLISECONDS.sleep(100);
+		verify(mockedEngine).reloadAllRules();
+	}
+
+	@Test
+	public void testThreadException() throws IOException {
+		String root = new File(".").getCanonicalPath();
+		String testRoute = root + "/src/test/java";
+		testDirectoryWatcher = new RulesUtilsDirectoryWatcher(Paths.get(testRoute), mockedEngine);
+
+		testDirectoryWatcher.start();
+		testDirectoryWatcher.stop();
+
+		verify(mockedEngine, never()).createDatastreamDirectory("tempDir");
+		verify(mockedEngine, never()).deleteDatastreamDirectory("tempDir");
+	}
+
+	@Test
+	public void testStop() {
+		Whitebox.setInternalState(testDirectoryWatcher, "creatingWatcherThread", mockedThread);
+
+		testDirectoryWatcher.stop();
+
+		verify(mockedThread).interrupt();
+	}
+}

--- a/oda-ruleengine/nashorn/src/main/java/es/amplia/oda/ruleengine/nashorn/Activator.java
+++ b/oda-ruleengine/nashorn/src/main/java/es/amplia/oda/ruleengine/nashorn/Activator.java
@@ -1,7 +1,7 @@
 package es.amplia.oda.ruleengine.nashorn;
 
-import es.amplia.oda.core.commons.utils.*;
-import es.amplia.oda.ruleengine.api.ScriptTranslator;
+import es.amplia.oda.core.commons.utils.ConfigurableBundle;
+import es.amplia.oda.core.commons.utils.ConfigurableBundleImpl;
 import es.amplia.oda.ruleengine.nashorn.configuration.RuleEngineConfigurationHandler;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
@@ -15,7 +15,7 @@ public class Activator implements BundleActivator {
 
 	private ConfigurableBundle configurableBundle;
 	private RuleEngineNashorn ruleEngine;
-	private ScriptTranslator scriptTranslator;
+	private NashornScriptTranslator scriptTranslator;
 	private ServiceRegistration<es.amplia.oda.ruleengine.api.RuleEngine> ruleEngineServiceRegistration;
 
 
@@ -25,9 +25,11 @@ public class Activator implements BundleActivator {
 
 		scriptTranslator = new NashornScriptTranslator();
 		ruleEngine = new RuleEngineNashorn(scriptTranslator);
-		RuleEngineConfigurationHandler engineConfigurationHandler = new RuleEngineConfigurationHandler(ruleEngine);
+		RuleEngineConfigurationHandler engineConfigurationHandler = new RuleEngineConfigurationHandler(ruleEngine,
+				scriptTranslator);
 		configurableBundle = new ConfigurableBundleImpl(bundleContext, engineConfigurationHandler);
-		ruleEngineServiceRegistration = bundleContext.registerService(es.amplia.oda.ruleengine.api.RuleEngine.class, ruleEngine, null);
+		ruleEngineServiceRegistration = bundleContext.registerService(es.amplia.oda.ruleengine.api.RuleEngine.class,
+				ruleEngine, null);
 
 		LOGGER.info("Rule engine started");
 	}

--- a/oda-ruleengine/nashorn/src/main/java/es/amplia/oda/ruleengine/nashorn/NashornScriptTranslator.java
+++ b/oda-ruleengine/nashorn/src/main/java/es/amplia/oda/ruleengine/nashorn/NashornScriptTranslator.java
@@ -1,6 +1,7 @@
 package es.amplia.oda.ruleengine.nashorn;
 
 import es.amplia.oda.ruleengine.api.ScriptTranslator;
+import es.amplia.oda.ruleengine.nashorn.configuration.RuleEngineConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -8,20 +9,34 @@ import javax.script.Invocable;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.util.HashMap;
+import java.util.Scanner;
 
 public class NashornScriptTranslator implements ScriptTranslator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(es.amplia.oda.ruleengine.nashorn.NashornScriptTranslator.class);
     private static final String ENGINE_NAME = "nashorn";
+    private String jsUtilsPath;
 
     private HashMap<String,ScriptEngine> engines = new HashMap<>();
+
+    public void loadConfiguration(RuleEngineConfiguration config) {
+        this.jsUtilsPath = config.getUtilsPath();
+    }
 
     @Override
     public void initScript(String script) throws ScriptException {
         ScriptEngineManager manager = new ScriptEngineManager();
         ScriptEngine engine = manager.getEngineByName(ENGINE_NAME);
-        engine.eval("load('" + script + "')");
+
+        // all rules will have preloaded all the functions from utils.js
+        engine.eval("load('" + jsUtilsPath + "utils.js" + "')");
+
+        // load rule
+        engine.eval(readFile(script));
+
         engines.put(script, engine);
     }
 
@@ -47,5 +62,42 @@ public class NashornScriptTranslator implements ScriptTranslator {
     public void close() {
         // With this library is not required, but in others objects have to be closed before stop the program.
         engines.clear();
+    }
+
+    private String readFile(String file) {
+        try (Scanner script = new Scanner(new File(file))) {
+            StringBuilder scriptContent = new StringBuilder();
+
+            while (script.hasNext()) {
+                scriptContent.append(replaceLoadPath(script.nextLine()));
+            }
+
+            script.close();
+
+            return scriptContent.toString();
+        } catch (FileNotFoundException ignored) {
+        }
+        return "";
+    }
+
+    private String replaceLoadPath(String stringToCheck) {
+        // if rule contains lines to load another javascript, its path must be added
+        // load("script.js") lines must be treated to add the path where script.js is stored
+        // final result will be load("jslib/script.js")
+        String loadString = "load(";
+
+        if (stringToCheck.startsWith(loadString)) {
+
+            // If javascript to load is util.js, don't replace
+            // This adds compatibility with older versions where utils.js wasn't loaded internally
+            if (stringToCheck.contains("/utils.js")) {
+                return stringToCheck;
+            }
+
+            String jsToLoad = stringToCheck.substring(stringToCheck.indexOf(loadString) + loadString.length() + 1);
+            return loadString + "\"" + jsUtilsPath + jsToLoad;
+        }
+
+        return stringToCheck;
     }
 }

--- a/oda-ruleengine/nashorn/src/main/java/es/amplia/oda/ruleengine/nashorn/NashornScriptTranslator.java
+++ b/oda-ruleengine/nashorn/src/main/java/es/amplia/oda/ruleengine/nashorn/NashornScriptTranslator.java
@@ -72,10 +72,10 @@ public class NashornScriptTranslator implements ScriptTranslator {
                 scriptContent.append(replaceLoadPath(script.nextLine()));
             }
 
-            script.close();
-
             return scriptContent.toString();
-        } catch (FileNotFoundException ignored) {
+        } catch (FileNotFoundException e) {
+            LOGGER.error("File not found {}", file);
+
         }
         return "";
     }
@@ -88,10 +88,10 @@ public class NashornScriptTranslator implements ScriptTranslator {
 
         if (stringToCheck.startsWith(loadString)) {
 
-            // If javascript to load is util.js, don't replace
+            // If javascript to load is util.js, return empty string
             // This adds compatibility with older versions where utils.js wasn't loaded internally
             if (stringToCheck.contains("/utils.js")) {
-                return stringToCheck;
+                return "";
             }
 
             String jsToLoad = stringToCheck.substring(stringToCheck.indexOf(loadString) + loadString.length() + 1);

--- a/oda-ruleengine/nashorn/src/main/java/es/amplia/oda/ruleengine/nashorn/RuleEngineNashorn.java
+++ b/oda-ruleengine/nashorn/src/main/java/es/amplia/oda/ruleengine/nashorn/RuleEngineNashorn.java
@@ -161,7 +161,7 @@ public class RuleEngineNashorn implements es.amplia.oda.ruleengine.api.RuleEngin
         try {
             this.rules.put(nameRule, new Rule(nameRule, datastreamIds, script));
         } catch (ScriptException e) {
-            LOGGER.error("Cannot init rule {}: {}", nameRule, e.getMessage());
+           LOGGER.error("Cannot init rule {}: {}", nameRule, e.getMessage());
         }
     }
 

--- a/oda-ruleengine/nashorn/src/main/java/es/amplia/oda/ruleengine/nashorn/configuration/RuleEngineConfiguration.java
+++ b/oda-ruleengine/nashorn/src/main/java/es/amplia/oda/ruleengine/nashorn/configuration/RuleEngineConfiguration.java
@@ -7,4 +7,5 @@ import lombok.Value;
 @Builder
 public class RuleEngineConfiguration {
 	String path;
+	String utilsPath;
 }

--- a/oda-ruleengine/nashorn/src/main/java/es/amplia/oda/ruleengine/nashorn/configuration/RuleEngineConfigurationHandler.java
+++ b/oda-ruleengine/nashorn/src/main/java/es/amplia/oda/ruleengine/nashorn/configuration/RuleEngineConfigurationHandler.java
@@ -2,6 +2,7 @@ package es.amplia.oda.ruleengine.nashorn.configuration;
 
 import es.amplia.oda.core.commons.exceptions.ConfigurationException;
 import es.amplia.oda.core.commons.utils.ConfigurationUpdateHandler;
+import es.amplia.oda.ruleengine.nashorn.NashornScriptTranslator;
 import es.amplia.oda.ruleengine.nashorn.RuleEngineNashorn;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,12 +16,17 @@ public class RuleEngineConfigurationHandler implements ConfigurationUpdateHandle
 	private static final Logger LOGGER = LoggerFactory.getLogger(RuleEngineConfigurationHandler.class);
 
 	private static final String PATH_PROPERTY_NAME = "path";
+	private static final String UTILS_PATH_PROPERTY_NAME = "utilsPath";
+
 
 	private RuleEngineConfiguration config;
 	RuleEngineNashorn ruleEngine;
+	NashornScriptTranslator scriptTranslator;
 
-	public RuleEngineConfigurationHandler(RuleEngineNashorn ruleEngine) {
+
+	public RuleEngineConfigurationHandler(RuleEngineNashorn ruleEngine, NashornScriptTranslator scriptTranslator) {
 		this.ruleEngine = ruleEngine;
+		this.scriptTranslator = scriptTranslator;
 	}
 
 	@Override
@@ -31,6 +37,8 @@ public class RuleEngineConfigurationHandler implements ConfigurationUpdateHandle
 
 		builder.path(Optional.ofNullable((String) props.get(PATH_PROPERTY_NAME))
 				.orElseThrow(() ->  missingPathExceptionSupplier().get()));
+		builder.utilsPath(Optional.ofNullable((String) props.get(UTILS_PATH_PROPERTY_NAME))
+				.orElseThrow(() ->  missingPathExceptionSupplier().get()));
 
 		config = builder.build();
 
@@ -39,6 +47,7 @@ public class RuleEngineConfigurationHandler implements ConfigurationUpdateHandle
 
 	@Override
 	public void applyConfiguration() {
+		this.scriptTranslator.loadConfiguration(this.config);
 		this.ruleEngine.loadConfiguration(this.config);
 	}
 

--- a/oda-ruleengine/nashorn/src/test/java/es/amplia/oda/ruleengine/nashorn/ActivatorTest.java
+++ b/oda-ruleengine/nashorn/src/test/java/es/amplia/oda/ruleengine/nashorn/ActivatorTest.java
@@ -55,7 +55,7 @@ public class ActivatorTest {
 
 		verifyNew(NashornScriptTranslator.class).withNoArguments();
 		verifyNew(RuleEngineNashorn.class).withArguments(eq(mockedTranslator));
-		verifyNew(RuleEngineConfigurationHandler.class).withArguments(eq(mockedRuleEngine));
+		verifyNew(RuleEngineConfigurationHandler.class).withArguments(eq(mockedRuleEngine), eq(mockedTranslator));
 		verifyNew(ConfigurableBundleImpl.class).withArguments(eq(mockedContext), eq(mockedRuleEngineHandler));
 	}
 

--- a/oda-ruleengine/nashorn/src/test/java/es/amplia/oda/ruleengine/nashorn/NashornScriptTranslatorTest.java
+++ b/oda-ruleengine/nashorn/src/test/java/es/amplia/oda/ruleengine/nashorn/NashornScriptTranslatorTest.java
@@ -50,6 +50,7 @@ public class NashornScriptTranslatorTest {
 		whenNew(ScriptEngineManager.class).withAnyArguments().thenReturn(mockedManager);
 		when(mockedManager.getEngineByName(any())).thenReturn(mockedEngine);
 		String root = new File(".").getCanonicalPath();
+		Whitebox.setInternalState(testTranslator, "jsUtilsPath", root + "/src/test/");
 		File ruleFilToCreate = new File(root + "/src/test/rule.js");
 		ruleFilToCreate.createNewFile();
 		FileOutputStream output = new FileOutputStream(root + "/src/test/rule.js");
@@ -58,7 +59,7 @@ public class NashornScriptTranslatorTest {
 		String script = root + "/src/test/rule.js";
 		testTranslator.initScript(script);
 
-		verify(mockedEngine).eval("load('" + script + "')");
+		verify(mockedEngine).eval("*");
 		assertTrue(((HashMap) Whitebox.getInternalState(testTranslator, "engines")).size() > 0);
 		output.close();
 		ruleFilToCreate.delete();
@@ -72,7 +73,7 @@ public class NashornScriptTranslatorTest {
 		String script = "none file to do the test";
 		testTranslator.initScript(script);
 
-		verify(mockedEngine).eval("load('" + script + "')");
+		verify(mockedEngine).eval("");
 		assertTrue(((HashMap) Whitebox.getInternalState(testTranslator, "engines")).size() > 0);
 	}
 

--- a/oda-ruleengine/nashorn/src/test/java/es/amplia/oda/ruleengine/nashorn/NashornScriptTranslatorTest.java
+++ b/oda-ruleengine/nashorn/src/test/java/es/amplia/oda/ruleengine/nashorn/NashornScriptTranslatorTest.java
@@ -2,6 +2,7 @@ package es.amplia.oda.ruleengine.nashorn;
 
 import es.amplia.oda.core.commons.utils.DatastreamValue;
 import es.amplia.oda.core.commons.utils.State;
+import es.amplia.oda.ruleengine.nashorn.configuration.RuleEngineConfiguration;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -16,6 +17,10 @@ import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
@@ -140,5 +145,53 @@ public class NashornScriptTranslatorTest {
 		State state = (State) testTranslator.runMethod("rule.js", "nothing", mockedState, value);
 
 		assertEquals(mockedState, state);
+	}
+
+	@Test
+	public void testReplaceLoadPath() throws ScriptException, IOException {
+
+		String root = new File(".").getCanonicalPath() + "/src/test/java/rules/";
+		Whitebox.setInternalState(testTranslator, "jsUtilsPath", root + "jsUtils/");
+
+		// rule file
+		String rulePath = root + "rule";
+		Files.createDirectories(Paths.get(rulePath));
+		String ruleName = rulePath + "/rule.js";
+		File ruleFile = new File(ruleName);
+		ruleFile.createNewFile();
+		FileWriter fileWriter = new FileWriter(ruleName);
+		fileWriter.write("load(\"utils.js\");\n function nothing(a, b) \n {return a}");
+		fileWriter.close();
+
+		// js utils file
+		String jsUtilsPath = root + "/jsUtils";
+		Files.createDirectories(Paths.get(jsUtilsPath));
+		String jsUtilsName = jsUtilsPath + "/utils.js";
+		File jsUtilsFile = new File(jsUtilsName);
+		jsUtilsFile.createNewFile();
+
+		// launch method
+		testTranslator.initScript(ruleName);
+
+		// test condition
+		assertTrue(((HashMap) Whitebox.getInternalState(testTranslator, "engines")).size() > 0);
+
+		// clean files created
+		ruleFile.delete();
+		jsUtilsFile.delete();
+		Files.delete(Paths.get(rulePath));
+		Files.delete(Paths.get(jsUtilsPath));
+		Files.delete(Paths.get(root));
+	}
+
+	@Test
+	public void testLoadConfiguration() throws Exception {
+		String root = new File(".").getCanonicalPath() + "/src/test/java/rules/";
+		RuleEngineConfiguration config = RuleEngineConfiguration.builder().path(root + "/src/test/java/rules/testDirectory")
+				.utilsPath(root + "/src/test/java/rules/testDirectory").build();
+
+		testTranslator.loadConfiguration(config);
+
+		assertEquals(Whitebox.getInternalState(testTranslator, "jsUtilsPath"), root + "/src/test/java/rules/testDirectory");
 	}
 }

--- a/oda-ruleengine/nashorn/src/test/java/es/amplia/oda/ruleengine/nashorn/RuleEngineNashornTest.java
+++ b/oda-ruleengine/nashorn/src/test/java/es/amplia/oda/ruleengine/nashorn/RuleEngineNashornTest.java
@@ -54,7 +54,8 @@ public class RuleEngineNashornTest {
 	@Test
 	public void testLoadConfiguration() throws Exception {
 		String root = new File(".").getCanonicalPath();
-		RuleEngineConfiguration config = RuleEngineConfiguration.builder().path(root + "/src/test/java/testDirectory").build();
+		RuleEngineConfiguration config = RuleEngineConfiguration.builder().path(root + "/src/test/java/testDirectory")
+				.utilsPath(root + "/src/test/java/testDirectory").build();
 		whenNew(MainDirectoryWatcher.class).withAnyArguments().thenReturn(mockedMainWatcher);
 		whenNew(RulesDirectoryWatcher.class).withAnyArguments().thenReturn(mockedRuleWatcher);
 
@@ -77,7 +78,8 @@ public class RuleEngineNashornTest {
 	@Test
 	public void testLoadConfigurationRuleException() throws Exception {
 		String root = new File(".").getCanonicalPath();
-		RuleEngineConfiguration config = RuleEngineConfiguration.builder().path(root + "/src/test/java/testDirectory").build();
+		RuleEngineConfiguration config = RuleEngineConfiguration.builder().path(root + "/src/test/java/testDirectory")
+				.utilsPath(root + "/src/test/java/testDirectory").build();
 		whenNew(MainDirectoryWatcher.class).withAnyArguments().thenReturn(mockedMainWatcher);
 		whenNew(RulesDirectoryWatcher.class).withAnyArguments().thenReturn(mockedRuleWatcher);
 		whenNew(Rule.class).withAnyArguments().thenThrow(ScriptException.class);
@@ -324,6 +326,50 @@ public class RuleEngineNashornTest {
 		Files.delete(Paths.get(rule2Path));
 		Files.delete(Paths.get(rule3Path));
 		Files.delete(Paths.get(rule4Path));
+		Files.delete(Paths.get(root));
+	}
+
+	@Test
+	public void testReloadAllRules() throws IOException {
+
+		String root = new File(".").getCanonicalPath() + "/src/test/java/rules/";
+
+		// initial conditions
+		Whitebox.setInternalState(testRuleEngine, "path", root);
+		// create and store rules
+		HashMap<String, Rule> rules = new HashMap<>();
+		Whitebox.setInternalState(testRuleEngine, "rules", rules);
+
+
+		// rule1
+		String rule1Path = root + "rule1";
+		Files.createDirectories(Paths.get(rule1Path));
+		String rule1Name = rule1Path + "/rule1.js";
+		File rule1File = new File(rule1Name);
+		rule1File.createNewFile();
+		// rule2
+		String rule2Path = root + "rule2";
+		Files.createDirectories(Paths.get(rule2Path));
+		String rule2Name = rule2Path + "/rule2.js";
+		File rule2File = new File(rule2Name);
+		rule2File.createNewFile();
+
+		// test before method call
+		rules = Whitebox.getInternalState(testRuleEngine, "rules");
+		assertEquals(0, rules.size());
+
+		// call method to test
+		testRuleEngine.reloadAllRules();
+
+		// assertions
+		rules = Whitebox.getInternalState(testRuleEngine, "rules");
+		assertEquals(2, rules.size());
+
+		// clean files created
+		rule1File.delete();
+		rule2File.delete();
+		Files.delete(Paths.get(rule1Path));
+		Files.delete(Paths.get(rule2Path));
 		Files.delete(Paths.get(root));
 	}
 }

--- a/oda-ruleengine/nashorn/src/test/java/es/amplia/oda/ruleengine/nashorn/configuration/RuleEngineNashornConfigurationHandlerTest.java
+++ b/oda-ruleengine/nashorn/src/test/java/es/amplia/oda/ruleengine/nashorn/configuration/RuleEngineNashornConfigurationHandlerTest.java
@@ -1,5 +1,6 @@
 package es.amplia.oda.ruleengine.nashorn.configuration;
 
+import es.amplia.oda.core.commons.exceptions.ConfigurationException;
 import es.amplia.oda.ruleengine.nashorn.NashornScriptTranslator;
 import es.amplia.oda.ruleengine.nashorn.RuleEngineNashorn;
 import org.junit.Before;
@@ -48,5 +49,13 @@ public class RuleEngineNashornConfigurationHandlerTest {
 		testHandler.applyConfiguration();
 
 		verify(mockedEngine).loadConfiguration(null);
+	}
+
+	@Test(expected = ConfigurationException.class)
+	public void testMissingPath() {
+		Dictionary<String, String> props = new Hashtable<>();
+		props.put("path", "this/is/a/path");
+
+		testHandler.loadConfiguration(props);
 	}
 }

--- a/oda-ruleengine/nashorn/src/test/java/es/amplia/oda/ruleengine/nashorn/configuration/RuleEngineNashornConfigurationHandlerTest.java
+++ b/oda-ruleengine/nashorn/src/test/java/es/amplia/oda/ruleengine/nashorn/configuration/RuleEngineNashornConfigurationHandlerTest.java
@@ -1,5 +1,6 @@
 package es.amplia.oda.ruleengine.nashorn.configuration;
 
+import es.amplia.oda.ruleengine.nashorn.NashornScriptTranslator;
 import es.amplia.oda.ruleengine.nashorn.RuleEngineNashorn;
 import org.junit.Before;
 import org.junit.Test;
@@ -20,17 +21,20 @@ public class RuleEngineNashornConfigurationHandlerTest {
 	RuleEngineConfigurationHandler testHandler;
 
 	@Mock
+	NashornScriptTranslator mockedScriptTranslator;
+	@Mock
 	RuleEngineNashorn mockedEngine;
 
 	@Before
 	public void setUp() {
-		testHandler = new RuleEngineConfigurationHandler(mockedEngine);
+		testHandler = new RuleEngineConfigurationHandler(mockedEngine, mockedScriptTranslator);
 	}
 
 	@Test
 	public void testLoadConfiguration() {
 		Dictionary<String, String> props = new Hashtable<>();
 		props.put("path", "this/is/a/path");
+		props.put("utilsPath", "this/is/another/path");
 
 		testHandler.loadConfiguration(props);
 


### PR DESCRIPTION
[ODA-339] [ODA-340] - Los ficheros javascript con métodos comunes a las reglas se tratarán como librerías. En las reglas no hará falta indicar el directorio donde esté el fichero javascript a cargar y el utils.js se cargará automáticamente para todas las reglas sin necesidad de especificarlo.